### PR TITLE
Fix typo in brightness script

### DIFF
--- a/.config/i3/scripts/brightness.sh
+++ b/.config/i3/scripts/brightness.sh
@@ -35,7 +35,7 @@ timeout=1500
 defaultBrightnessChangeValue=1
 defaultTempChangeValue=100
 screensaverBrightnessValue=1
-# Transitions smoothnesss and time
+# Transitions smoothness and time
 fade_steps=1
 fade_time=100
 fade_fps=240


### PR DESCRIPTION
## Summary
- fix a typo in the brightness control script comment

## Testing
- `bash -n .config/i3/scripts/brightness.sh`

------
https://chatgpt.com/codex/tasks/task_e_684163ef2b148330ae6e61b89dbe5fbe