### PR TITLE
Update brightness script for xbacklight options

### DIFF
--- a/.config/i3/scripts/brightness.sh
+++ b/.config/i3/scripts/brightness.sh
@@ -166,11 +166,11 @@ function printTemperature() {
 }
 
 function screensaver() {
-	trap 'exit 0' TERM INT
-	trap "setBrightness $(getBrightness); kill %%" EXIT
-	setBrightness "$screensaverBrightnessValue -fps $screensaver_fps -time $screensaver_time"
-	sleep 2147483647 &
-	wait
+        trap 'exit 0' TERM INT
+        trap "setBrightness $(getBrightness); kill %%" EXIT
+        xbacklight -set "$screensaverBrightnessValue" -steps "$screensaver_steps" -time "$screensaver_time"
+        sleep 2147483647 &
+        wait
 }
 
 case $1 in
@@ -190,10 +190,10 @@ case $1 in
 			fi
 			sendNotification
 			;;
-		set)
-			setBrightness "$2 -step $fade_fps -time $fade_time"
-			sendNotification
-			;;
+               set)
+                        xbacklight -set "$2" -steps "$fade_steps" -time "$fade_time"
+                        sendNotification
+                        ;;
 		screensaver)
 			screensaver
 			;;


### PR DESCRIPTION
## Summary
- modify `screensaver()` to call `xbacklight` directly
- update `set` case to use `xbacklight -set` with fade settings

## Testing
- `shellcheck .config/i3/scripts/brightness.sh`

------
https://chatgpt.com/codex/tasks/task_e_68416492797c8330be429b740231911d