### PR TITLE
Add brightness tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ cp .config/i3/* ~/.config/i3/
 ```bash
 cp .config/polybar/* ~/.config/polybar/
 ```
+
+## Running tests
+
+Install `bats` using your package manager (on Debian/Ubuntu: `sudo apt-get install bats`).
+Then run all tests with:
+
+```bash
+bats tests
+```

--- a/tests/brightness.bats
+++ b/tests/brightness.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup() {
+    TMPDIR=$(mktemp -d)
+    cat <<'SH' > "$TMPDIR/xbacklight"
+#!/bin/sh
+if [ "$1" = "-get" ]; then
+  echo 50
+fi
+SH
+    chmod +x "$TMPDIR/xbacklight"
+    export STUBPATH="$TMPDIR"
+}
+
+@test "brightness.sh print extended outputs bar and percentage" {
+    run env HOME="$PWD" PATH="$STUBPATH:$PATH" bash ./.config/i3/scripts/brightness.sh print extended
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"│"* ]]
+    [[ "$output" == *"%"* ]]
+}


### PR DESCRIPTION
## Summary
- add Bats tests verifying brightness script output
- document how to run tests in README

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68416499e64883308ea237205f685088